### PR TITLE
Document.write() support

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -140,7 +140,7 @@ div[class~=consoleFrame] {
 	line-height: 1.6;
 }
 
-#adURI, #adFragment {
+#adURI, #adFragment, #adHeadScript {
     width:70%;
 }
 

--- a/index.html
+++ b/index.html
@@ -171,11 +171,15 @@
     
         <section>
             <div>
+                <h2 class="no-margin">head script</h2>
+                <div>
+                    <textarea name="adHeadScript" id="adHeadScript" rows="10" placeholder="JavaScript that goes into head tag (executed before page loads)"></textarea><br/>
+                </div>
                 <h2 class="no-margin">tag source</h2>
                 <div>
                     <textarea name="adFragment" id="adFragment" rows="10" placeholder="Your HTML fragment here"></textarea><br/>
-                    <input type="button" value="Render" onclick="renderHtmlAd()" />
                 </div>
+                <input type="button" value="Render" onclick="renderHtmlAd()" />
             </div>
         </section>
         

--- a/index.html
+++ b/index.html
@@ -174,6 +174,7 @@
                 <h2 class="no-margin">head script</h2>
                 <div>
                     <textarea name="adHeadScript" id="adHeadScript" rows="10" placeholder="JavaScript that goes into head tag (executed before page loads)"></textarea><br/>
+                    <input type="checkbox" id="adHeadScriptIsURI" checked="checked" /> Use script's URL. <i>When this option is checked, paste a URL of the script instead of its source</i>
                 </div>
                 <h2 class="no-margin">tag source</h2>
                 <div>

--- a/safari/device.html
+++ b/safari/device.html
@@ -1,14 +1,6 @@
 <html>
 <head>
 	<title>Device Simulator</title>
-	<script type="text/javascript">
-		// Load head script from local storage
-		var adHeadScript = localStorage.getItem('adHeadScript');
-		if (adHeadScript) {
-			eval(adHeadScript);
-			localStorage.removeItem('adHeadScript');
-		}
-	</script>
 </head>
 <!--
 /*

--- a/safari/device.html
+++ b/safari/device.html
@@ -1,6 +1,14 @@
 <html>
 <head>
 	<title>Device Simulator</title>
+	<script type="text/javascript">
+		// Load head script from local storage
+		var adHeadScript = localStorage.getItem('adHeadScript');
+		if (adHeadScript) {
+			eval(adHeadScript);
+			localStorage.removeItem('adHeadScript');
+		}
+	</script>
 </head>
 <!--
 /*

--- a/safari/main.js
+++ b/safari/main.js
@@ -77,7 +77,11 @@ function nextStep() {
 function renderHtmlAd() {
 	var form = document.forms.setup;
     prepareMraidView(form);
-    mraidview.setAdHeadScript(form.adHeadScript.value);
+    if (form.adHeadScriptIsURI.value) {
+    	mraidview.setAdHeadScript("document.write('<script src=" + form.adHeadScript.value + "></script>');");
+    } else {
+    	mraidview.setAdHeadScript(form.adHeadScript.value);
+    }
 	mraidview.setUseHtml(true, form.adFragment.value);
 	mraidview.render();
 	$('[href=#tabs-3]').click(); // switch to third tab

--- a/safari/main.js
+++ b/safari/main.js
@@ -77,7 +77,7 @@ function nextStep() {
 function renderHtmlAd() {
 	var form = document.forms.setup;
     prepareMraidView(form);
-    if (form.adHeadScriptIsURI.value) {
+    if (form.adHeadScriptIsURI.checked) {
     	mraidview.setAdHeadScript("document.write('<script src=" + form.adHeadScript.value + "></script>');");
     } else {
     	mraidview.setAdHeadScript(form.adHeadScript.value);

--- a/safari/main.js
+++ b/safari/main.js
@@ -77,6 +77,7 @@ function nextStep() {
 function renderHtmlAd() {
 	var form = document.forms.setup;
     prepareMraidView(form);
+    mraidview.setAdHeadScript(form.adHeadScript.value);
 	mraidview.setUseHtml(true, form.adFragment.value);
 	mraidview.render();
 	$('[href=#tabs-3]').click(); // switch to third tab

--- a/safari/mraidview.js
+++ b/safari/mraidview.js
@@ -134,6 +134,7 @@ INFO mraid.js identification script found
 
     var
         adURI = "",
+        adHeadScript = "",
         adURIFragment = true,
         adHtml = '',
         useHtml = false;
@@ -213,6 +214,12 @@ INFO mraid.js identification script found
         adURI = uri;
         adURIFragment = (fragment)?true:false;
     };
+    
+    mraidview.setAdHeadScript = function(script) {
+    	adHeadScript = script;
+    	// Save in local storage
+    	localStorage.setItem('adHeadScript', adHeadScript);
+    }
 
     mraidview.setUseHtml = function(useThisHtml, html) {
         useHtml = useThisHtml;

--- a/safari/mraidview.js
+++ b/safari/mraidview.js
@@ -217,8 +217,6 @@ INFO mraid.js identification script found
     
     mraidview.setAdHeadScript = function(script) {
     	adHeadScript = script;
-    	// Save in local storage
-    	localStorage.setItem('adHeadScript', adHeadScript);
     }
 
     mraidview.setUseHtml = function(useThisHtml, html) {
@@ -1061,6 +1059,15 @@ INFO mraid.js identification script found
         var win = this.contentWindow,
             doc = win.document,
             adScreen = {};
+
+        // Load ad from external script
+        if (adHeadScript) {
+            broadcastEvent(EVENTS.INFO, 'attaching head script');
+            var adScript = doc.createElement('script');
+            adScript.setAttribute('type', 'text/javascript');
+            adScript.innerHTML = adHeadScript;
+            doc.getElementsByTagName('head')[0].appendChild(adScript);
+        }
 
         for (var prop in win.screen) {
             if (prop !== 'width' && prop !== 'height') {


### PR DESCRIPTION
Hi,

I would like to submit some modifications to the webtester tool. Our company's ads are served from a dynamic javascript that relies on document.write() function to modify the underlying page. It is impossible to test such ad using HTML fragment, because by the time the script is executed, the DOM tree of the document is already built and calling document.write() will throw an error.
To support this functionality, I have added a new textbox on Flight page where a user can paste their JavaScript. The script is passed to device.html page and is executed while the page is loading, therefore enabling testing ads that rely on document.write() function.
A checkbox below the textbox allows switching between using a script's URL or a JavaScript source.

Please feel free to merge this functionality if you feel it will be useful for others as well.

Regards,

Dmitry
