### PR TITLE
Fix for issue#13: Screen Size value is pushed to the Ad

### DIFF
--- a/safari/mraidview.js
+++ b/safari/mraidview.js
@@ -1191,12 +1191,14 @@ INFO mraid.js identification script found
             adFrame.contentWindow.dispatchEvent(orientationChangeEvent);
             //adBridge.pushChange({'size': size, 'orientation': adContainerOrientation, 'currentPosition': currentPosition});
             currentPosition = {'x': currentPosition.y, 'y': (maxSize.width - expandProperties.width - currentPosition.x), 'width': currentPosition.height, 'height': currentPosition.width};
-            adBridge.pushChange({'size': size, 'orientation': adContainerOrientation, 'currentPosition': currentPosition});
+            screenSize = {width: screenSize.height, height: screenSize.width};
+            adBridge.pushChange({'size': size, 'orientation': adContainerOrientation, 'currentPosition': currentPosition, 'screenSize': screenSize});
         }
     };
 
     var updateAdSize = function(val){
         setMaxAdArea(val);
+
         setExpandProperties(val);
     };
 })();

--- a/safari/mraidview.js
+++ b/safari/mraidview.js
@@ -1198,7 +1198,6 @@ INFO mraid.js identification script found
 
     var updateAdSize = function(val){
         setMaxAdArea(val);
-
         setExpandProperties(val);
     };
 })();


### PR DESCRIPTION
The screen size is correctly pushed to the that Ad. The mraid.getScreenSize() is now correct for the landscape and portrait orientation.
