### PR TITLE
Fixes #7, The currentPosition width and height should not be switched

### DIFF
--- a/safari/mraidview.js
+++ b/safari/mraidview.js
@@ -1189,8 +1189,6 @@ INFO mraid.js identification script found
             var orientationChangeEvent = adFrame.contentWindow.document.createEvent('HTMLEvents');
             orientationChangeEvent.initEvent('orientationchange', false, false);
             adFrame.contentWindow.dispatchEvent(orientationChangeEvent);
-            //adBridge.pushChange({'size': size, 'orientation': adContainerOrientation, 'currentPosition': currentPosition});
-            currentPosition = {'x': currentPosition.y, 'y': (maxSize.width - expandProperties.width - currentPosition.x), 'width': currentPosition.height, 'height': currentPosition.width};
             adBridge.pushChange({'size': size, 'orientation': adContainerOrientation, 'currentPosition': currentPosition});
         }
     };


### PR DESCRIPTION
The currentPosition width and height where being switched by orientation change. This step was not necessary and caused the current position width and height to be inverted after the second 2 orientation changes.

I have tested default, resized, expanded and locked expanded states and then currentPosition values are not correct after 2 orientation changes for each state.



