### PR TITLE
Fixed #7, #16, #13

### DIFF
--- a/safari/mraidview.js
+++ b/safari/mraidview.js
@@ -1189,8 +1189,6 @@ INFO mraid.js identification script found
             var orientationChangeEvent = adFrame.contentWindow.document.createEvent('HTMLEvents');
             orientationChangeEvent.initEvent('orientationchange', false, false);
             adFrame.contentWindow.dispatchEvent(orientationChangeEvent);
-            //adBridge.pushChange({'size': size, 'orientation': adContainerOrientation, 'currentPosition': currentPosition});
-            currentPosition = {'x': currentPosition.y, 'y': (maxSize.width - expandProperties.width - currentPosition.x), 'width': currentPosition.height, 'height': currentPosition.width};
             adBridge.pushChange({'size': size, 'orientation': adContainerOrientation, 'currentPosition': currentPosition});
         }
     };


### PR DESCRIPTION
All the fixes made on the webtester have been merged into a single merge request:

Fix #7 - The currentPosition width and height should not be switched
The currentPosition width and height where being switched by orientation change. This step was not necessary and caused the current position width and height to be inverted after the second 2 orientation changes.

I have tested default, resized, expanded and locked expanded states and then currentPosition values are not correct after 2 orientation changes for each state.

Fix #16, #13 Fixed the Resize boundary check
The original boundary check only checked if a resize was valid according to the starting max screen size. The fix essentially checks according to the current orientation max screen size.

The ScreenSize is also switched by orientation and pushed to the AdContainer via the adBridge

