### PR TITLE
First draft of a functioning MRAID Video Addendum v1 implementation in WebTester

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
                     <table id="geometryTable"> 
                         <tr><td class="name">Default ad size (w x h):</td>
                             <td class="value">
-                                <input id="adWidth" name="adWidth" class="dimension" value="320" onchange="devicesizeWidget.updatePreview()"/>x<input id="adHeight" name="adHeight" class="dimension" value="50" onchange="devicesizeWidget.updatePreview()"/>
+                                <input id="adWidth" name="adWidth" class="dimension" value="320" onchange="devicesizeWidget.updatePreview()"/>x<input id="adHeight" name="adHeight" class="dimension" value="480" onchange="devicesizeWidget.updatePreview()"/>
                             </td>
                         </tr>
                         <tr><td class="name">Default ad position (top, left):</td>
@@ -121,8 +121,8 @@
                     </p>
                     <p class="no-margin">Placement: 
                         <select name="placement">
-                            <option value="inline" selected="selected">Inline</option>
-                            <option value="interstitial">Interstitial</option>
+                            <option value="interstitial" selected="selected">Interstitial</option>
+                            <option value="imline">Inline</option>
                         </select>
                         </br>
                         <input id="offscreen" name="offscreen" type="checkbox"/>Off-screen
@@ -173,7 +173,8 @@
             <div>
                 <h2 class="no-margin">tag source</h2>
                 <div>
-                    <textarea name="adFragment" id="adFragment" rows="10" placeholder="Your HTML fragment here"></textarea><br/>
+                    <!--textarea name="adFragment" id="adFragment" rows="10" ><script src='http://rtr.innovid.com/r1.5637e6df321548.45146407;cb=[timestamp]'></script></textarea><br/-->
+                    <textarea name="adFragment" id="adFragment" rows="10" placeHolder="Your HTML fragment here" ></textarea><br/>
                     <input type="button" value="Render" onclick="renderHtmlAd()" />
                 </div>
             </div>

--- a/safari/main.js
+++ b/safari/main.js
@@ -65,7 +65,8 @@ var features = {
     tel: { name: 'tel' },
     calendar: { name: 'calendar' },
     storePicture: { name: 'storePicture' },
-    inlineVideo: {name: 'inlineVideo' }
+    inlineVideo: {name: 'inlineVideo' },
+    vpaid: {name: 'vpaid' }
 };
 
 function contains(array, item) {

--- a/safari/mraid-main.js
+++ b/safari/mraid-main.js
@@ -69,7 +69,8 @@
         TEL         :'tel',
         CALENDAR    :'calendar',
         STOREPICTURE:'storePicture',
-        INLINEVIDEO	:'inlineVideo'
+        INLINEVIDEO	:'inlineVideo',
+        VPAID    	:'vpaid'
     };
 
     // PRIVATE PROPERTIES (sdk controlled) //////////////////////////////////////////////////////
@@ -424,6 +425,9 @@
         isViewable:function(val) {
             broadcastEvent(EVENTS.INFO, 'setting isViewable to ' + stringify(val));
             isViewable = val;
+            if (mraid.vpaid && mraid.vpaid.ready && !mraid.vpaid.adStarted && isViewable){
+                mraid.vpaid.startAd();
+            }
             broadcastEvent(EVENTS.VIEWABLECHANGE, isViewable);
         },
         orientationProperties:function(val) {
@@ -796,6 +800,7 @@
 
     mraid.supports = function(feature) {
     /* introduced in MRAIDv2 */
+        broadcastEvent(EVENTS.INFO, "Ad calling mraid.supports(" + feature + ")");
         var bSupports = false;
         if (parseFloat(mraidVersion, 10) < 2) {
             broadcastEvent(EVENTS.ERROR, 'Method not supported by this version. (supports)', 'supports');
@@ -832,6 +837,31 @@
             } else {
                 mraidview.createCalendarEvent(params);
             }
+        }
+    };
+
+    mraid.initVpaid = function(vpaidObject){
+        /* introduced in MRAIDv2 Video Addendum v1*/
+        var script = document.createElement('script');
+        script.src = 'mraid-vpaid.js';
+        script.onload = function(e) {
+            mraid.vpaid = mraidVpaid(vpaidObject, mraid.vpaidEventHandler);
+            if (mraid.isViewable()) {
+                mraid.vpaid.startAd();
+            }
+        };
+        document.head.appendChild(script);
+    };
+
+    mraid.vpaidEventHandler = function(event){
+        switch (event){
+            case 'AdError' :
+                // Handle VPAID AdError event here
+                break
+            // case : Add other event to be handled here
+            default:
+                broadcastEvent(EVENTS.INFO, "VPAID Event : " + event);
+                break;
         }
     };
 

--- a/safari/mraid-vpaid.js
+++ b/safari/mraid-vpaid.js
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (c) 2012 The mraid-web-tester project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+(function(window) {
+      this.mraidVpaid = function( vpaidObject, eventHandler ) {
+          var eventRelay = !!eventHandler?eventHandler:function(){};
+          var adStarted = false,
+              vpaidEvents = {
+                AdStarted: function () {
+                    eventRelay("AdStarted");
+                    adStarted = true;
+                },
+                AdImpression: function () {
+                    eventRelay("AdImpression");
+                },
+                AdVideoStart: function () {
+                    eventRelay("AdVideoStart")
+                },
+                AdVideoFirstQuartile: function () {
+                    eventRelay("AdVideoFirstQuartile")
+                },
+                AdVideoMidpoint: function () {
+                    eventRelay("AdVideoMidpoint")
+                },
+                AdVideoThirdQuartile: function () {
+                    eventRelay("AdVideoThirdQuartile")
+                },
+                AdVideoComplete: function () {
+                    eventRelay("AdVideoComplete")
+                },
+                AdClickThru: function () {
+                    eventRelay("AdClickThru")
+                },
+                AdInteraction: function () {
+                    eventRelay("AdInteraction")
+                },
+                AdDurationChanged: function () {
+                    eventRelay("AdDurationChanged")
+                },
+                AdUserAcceptInvitation: function () {
+                    eventRelay("AdUserAcceptInvitation")
+                },
+                AdUserMinimize: function () {
+                    eventRelay("AdUserMinimize")
+                },
+                AdUserClose: function () {
+                    eventRelay("AdUserClose")
+                },
+                AdPaused: function () {
+                    eventRelay("AdPaused")
+                },
+                AdPlaying: function () {
+                    eventRelay("AdPlaying")
+                },
+                AdLog: function () {
+                    eventRelay("AdLog")
+                },
+                AdError: function () {
+                    eventRelay("AdError")
+                }
+            },
+        subscribe = function (callback, event) {
+            broadcastEvent('info', "VPAID : Container subscribing to event : " + event);
+            vpaidObject.subscribe(callback, event);
+        },
+        unsubscribe = function () {
+            broadcastEvent('info', "VPAID : Container unsubscribing from event : " + event);
+            vpaidObject.unsubscribe();
+        },
+        startAd = function () {
+            broadcastEvent('info', "VPAID : Container calling startAd() on Ad's VPAID Object");
+            vpaidObject.startAd();
+            this.adStarted = true;
+        },
+        getAdDuration = function () {
+            broadcastEvent('info', "VPAID : Container calling getAdDuration() on Ad's VPAID Object");
+            return vpaidObject.getAdDuration();
+        },
+        getAdRemainingTime = function () {
+            broadcastEvent('info', "VPAID : Container calling getAdRemainingTime() on Ad's VPAID Object");
+            vpaidObject.getAdRemainingTime();
+        };
+        for (event in vpaidEvents) {
+            subscribe(vpaidEvents[event], event);
+        }
+        return {
+            subscribe:subscribe,
+            unsubscribe:unsubscribe,
+            startAd:startAd,
+            getAdDuration:getAdDuration,
+            getAdRemainingTime:getAdRemainingTime
+        }
+      };
+})(window);

--- a/safari/mraidview.js
+++ b/safari/mraidview.js
@@ -90,7 +90,8 @@ INFO mraid.js identification script found
         TEL         :'tel',
         CALENDAR    :'calendar',
         STOREPICTURE:'storePicture',
-        INLINEVIDEO :'inlineVideo'
+        INLINEVIDEO :'inlineVideo',
+        VPAID       :'vpaid'
     };
 
     // EVENT HANDLING ///////////////////////////////////////////////////////////////
@@ -537,7 +538,7 @@ INFO mraid.js identification script found
         for (i=0; i<scriptsCount; i++) {
             script = doc.createElement('script');
             script.type = "text/javascript";
-            if (scripts[i].src !== '') {
+            if ([i].src !== '') {
                 script.src = scripts[i].src;
             } else {
                 script.text = scripts[i].text;


### PR DESCRIPTION
Adds mraid.supports('vpaid') to the webtester and implements the subset of VPAID specified in the MRAID Video Addendum v1 specification.
VPAID events are echoed to the INFO log as they are dispatched by a vpaid-enabled MRAID Ad.
