### PR TITLE
Fixed bug introduced in MRAID Video Addendum by accidental delete of 'scripts' term.

### DIFF
--- a/safari/mraidview.js
+++ b/safari/mraidview.js
@@ -538,7 +538,7 @@ INFO mraid.js identification script found
         for (i=0; i<scriptsCount; i++) {
             script = doc.createElement('script');
             script.type = "text/javascript";
-            if ([i].src !== '') {
+            if (scripts[i].src !== '') {
                 script.src = scripts[i].src;
             } else {
                 script.text = scripts[i].text;


### PR DESCRIPTION
Fixed bug introduced in mraidview.js in MRAID Video Addendum implementation, by accidental delete of 'scripts' term, while performing a text search.