### PR TITLE
Remove listener when function is provided

### DIFF
--- a/safari/mraid-main.js
+++ b/safari/mraid-main.js
@@ -607,9 +607,13 @@
         if (!event) {
             broadcastEvent(EVENTS.ERROR, 'Must specify an event.', 'removeEventListener');
         } else {
-            if (!listener || (typeof(listeners[event]) === 'undefined' || !listeners[event].remove(listener))) {
-                broadcastEvent(EVENTS.ERROR, 'Listener not currently registered for event: ' + event, 'removeEventListener');
-                return;
+            if (listener) {
+                if (typeof(listeners[event]) === 'undefined') {
+                    broadcastEvent(EVENTS.ERROR, 'Listener not currently registered for event: ' + event, 'removeEventListener');
+                    return;
+                }
+
+                listeners[event].remove(listener);
             } else {
                 listeners[event].removeAll();
             }


### PR DESCRIPTION
According to the spec if the listener function is provided in `removeEventListener`, only this listener is removed. The condition was bad and caused `listeners[event].remove(listener);` to never be called and `removeAll` to be called instead.

/cc @tomesch