### PR TITLE
Changed order of position labels to match fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
                                 <input id="adWidth" name="adWidth" class="dimension" value="320" onchange="devicesizeWidget.updatePreview()"/>x<input id="adHeight" name="adHeight" class="dimension" value="50" onchange="devicesizeWidget.updatePreview()"/>
                             </td>
                         </tr>
-                        <tr><td class="name">Default ad position (top, left):</td>
+                        <tr><td class="name">Default ad position (left, top):</td>
                             <td class="value">
                                 <input id="adLeft" name="adLeft" class="dimension" value="0" onchange="devicesizeWidget.updatePreview()"/>,<input id="adTop" name="adTop" class="dimension" value="430" onchange="devicesizeWidget.updatePreview()"/>
                             </td>
@@ -98,7 +98,7 @@
                                 <input id="adMaxWidth" name="adMaxWidth" class="dimension" value="320"/>x<input id="adMaxHeight" name="adMaxHeight" class="dimension" value="480" onchange="devicesizeWidget.updatePreview()"/>
                             </td>
                         </tr>
-                        <tr><td class="name">Max ad position (top, left):</td>
+                        <tr><td class="name">Max ad position (left, top):</td>
                             <td class="value">
                                 <input id="adMaxLeft" name="adMaxLeft" class="dimension" value="0" onchange="devicesizeWidget.updatePreview()"/>,<input id="adMaxTop" name="adMaxTop" class="dimension" value="0" onchange="devicesizeWidget.updatePreview()"/>
                             </td>


### PR DESCRIPTION
The 'top, left' labels on the Prepare tab don't match the order of fields. This changes their order.