### PR TITLE
Issue with padding in device.html (chrome)

### DIFF
--- a/safari/device.html
+++ b/safari/device.html
@@ -15,18 +15,18 @@
 <body style="margin:0px; padding:0px; background-color:white; overflow: hidden; font: 12px Arial, Helvetica, sans-serif;">
 <div id="maxArea" style="height: 100%; width: 100%; overflow: hidden; position: absolute; top: 0; left:0px;">
 	<div id="adContainer" data-isviewable="true" style="position:absolute; padding:0px; margin:0px; background-color:transparent;">
-		<div id="adResizeContainer" style="overflow:hidden; padding:0px; margin:0px; height:100%; padding:100%;">
+		<div id="adResizeContainer" style="overflow:hidden; padding:0px; margin:0px; height:100%;">
 			<a id="closeEventRegion" style="height: 50px; width: 50px; display: none; text-decoration: none; position: absolute; top: 0; right: 0;"></a>
 			<iframe id="adFrame" style="overflow:hidden; width: 100%; height: 100%; padding:0px; margin:0px; background-color:transparent;" scrolling="no" frameBorder="0"></iframe>
 		</div>
-	</div>	
+	</div>
 </div>
 <div>
 	<h1 style="font-family: Arial; font-size: 1.2em;">MRAID Web Tester</h1>
-	
+
 </div>
 <p>
-	Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc, quis gravida magna mi a libero. Fusce vulputate eleifend sapien. 
+	Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc, quis gravida magna mi a libero. Fusce vulputate eleifend sapien.
 </p>
 </body>
 </html>


### PR DESCRIPTION
I guess that this second padding does not belong there. In the current Chrome (Version 114.0.5735.198 (arm64)), this padding: 100% causes problems with the adResizeContainer div container. It has too much padding and the banner is not displayed. (see screenshot) In Firefox (MacOS) that's not a problem. 

<img width="1191" alt="Bildschirmfoto 2023-07-31 um 22 07 02" src="https://github.com/mraid/webtester/assets/42931318/70203c61-0a7e-432d-8815-cc5c7a181c26">
